### PR TITLE
fix: adjust scale position to avoid overlap

### DIFF
--- a/src/components/MapEditor.vue
+++ b/src/components/MapEditor.vue
@@ -321,7 +321,7 @@ onMounted(() => {
     maxWidth: 120,
     unit: 'metric',
   })
-  map.addControl(scaleControl, 'bottom-left')
+  map.addControl(scaleControl, 'top-left')
 
   map.on('load', () => {
     lockMapNorthUp()


### PR DESCRIPTION
将比例尺移动到左上角作为目前按钮与比例尺相互遮挡的 workaround，也许有更好的解决方案。
既有的比例尺在左下角的现状：
<img width="1342" height="1216" alt="屏幕截图 2026-02-18 125238" src="https://github.com/user-attachments/assets/818d97df-7efa-44e0-a53c-af7ffdeae205" />
试验过但由于美观问题放弃的，将提示和提示按钮向上提高 22px：
<img width="1306" height="1280" alt="屏幕截图 2026-02-18 130044" src="https://github.com/user-attachments/assets/6ab78f5c-5c87-4b81-9c18-a4a78fa94538" />
